### PR TITLE
Added mpn_perfect_power_p support to speed

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+2019-03-24 Seth Troisi <sethtroisi@google.com>
+
+	* tune/common.c (speed_mpn_perfect_power_p): New functions.
+	* tune/speed.h: Declare it.
+	* tune/speed.c (routine): Add mpn_perfect_power_p .
+
 2018-11-30  Torbjörn Granlund  <tg@gmplib.org>
 
 	* mpn/powerpc64/mode64/p9/gmp-mparam.h: New file.

--- a/tune/common.c
+++ b/tune/common.c
@@ -1781,6 +1781,19 @@ speed_mpn_root (struct speed_params *s)
 
 
 double
+speed_mpn_perfect_power_p (struct speed_params *s)
+{
+  SPEED_ROUTINE_MPN_PERFECT_POWER (mpn_perfect_power_p);
+}
+
+double
+speed_mpn_perfect_square_p (struct speed_params *s)
+{
+  SPEED_ROUTINE_MPN_PERFECT_SQUARE (mpn_perfect_square_p);
+}
+
+
+double
 speed_mpz_fac_ui (struct speed_params *s)
 {
   SPEED_ROUTINE_MPZ_FAC_UI (mpz_fac_ui);

--- a/tune/speed.c
+++ b/tune/speed.c
@@ -397,6 +397,9 @@ const struct routine_t {
   { "mpn_sqrt",          speed_mpn_sqrt             },
   { "mpn_root",          speed_mpn_root, FLAG_R     },
 
+  { "mpn_perfect_power_p",  speed_mpn_perfect_power_p,       },
+  { "mpn_perfect_square_p", speed_mpn_perfect_square_p,      },
+
   { "mpn_fib2_ui",       speed_mpn_fib2_ui,    FLAG_NODATA },
   { "mpz_fib_ui",        speed_mpz_fib_ui,     FLAG_NODATA },
   { "mpz_fib2_ui",       speed_mpz_fib2_ui,    FLAG_NODATA },

--- a/tune/speed.h
+++ b/tune/speed.h
@@ -3373,19 +3373,17 @@ int speed_routine_count_zeros_setup (struct speed_params *, mp_ptr, int, int);
 
 /* Calculate worst case for perfect_power
    Worst case is multiple prime factors larger than trial div limit. */
-#define SPEED_ROUTINE_MPN_PERFECT_POWER(function)		   	\
+#define SPEED_ROUTINE_MPN_PERFECT_POWER(function)		 	\
   {									\
     mpz_t     r, p;							\
     unsigned  i, power;							\
     double    t;							\
 									\
-    SPEED_RESTRICT_COND (s->size >= 1);					\
+    SPEED_RESTRICT_COND (s->size >= 10);				\
 									\
-    mpz_init(r);							\
-    mpz_init_set_ui (p, 20000);						\
-    mpz_nextprime(p, p);						\
-    mpz_nextprime(r, p);						\
-    power = s->size * GMP_LIMB_BYTES / log2(mpz_get_ui(r));		\
+    mpz_init_set_ui (p, (1 << 16) + 1);	/* larger than 1000th prime */	\
+    mpz_init_set_ui (r, (1 << 17) - 1);					\
+    power = s->size * GMP_NUMB_BITS / 17;				\
     mpz_pow_ui(r, r, power - 1);					\
     mpz_mul(r, r, p);							\
 									\
@@ -3408,12 +3406,9 @@ int speed_routine_count_zeros_setup (struct speed_params *, mp_ptr, int, int);
     unsigned  i, power;							\
     double    t;							\
 									\
-    SPEED_RESTRICT_COND (s->size >= 1);					\
-									\
-    mpz_init_set_ui (r, 20000);						\
-    mpz_nextprime(r, r);						\
-    power = s->size * GMP_LIMB_BYTES / (2 * log2(mpz_get_ui(r)));	\
-    mpz_pow_ui(r, r, 2 * power);					\
+    SPEED_RESTRICT_COND (s->size >= 2);					\
+    mpz_init_set_n (r, s->xp, s->size / 2);				\
+    mpz_pow_ui(r, r, 2);						\
 									\
     speed_starttime ();							\
     i = s->reps;							\


### PR DESCRIPTION
```
cd ~/Projects/git-gmp/build && make -j8 && cd tune && make speed -j8; time ./speed -s 200-100000 -t 10 -f 1.19 -P perfect_power mpn_perfect_power_p; time ./speed -s 2000-200000 -t 10 -f 1.19 -P perfect_square mpn_perfect_square_p;
```

![perfect_combined](https://user-images.githubusercontent.com/10172976/63217847-308aaa00-c102-11e9-90eb-bf139842ee82.png)

---

Weird timing artifact
![perfect_combined_badmeasure](https://user-images.githubusercontent.com/10172976/63217937-210c6080-c104-11e9-9c94-c10be7fec8dd.png)
 with random perfect_square



