### PR TITLE
tune/speed support for mpz_nextprime

### DIFF
--- a/tune/common.c
+++ b/tune/common.c
@@ -1722,6 +1722,11 @@ speed_mpn_gcd_1N (struct speed_params *s)
   SPEED_ROUTINE_MPN_GCD_1N (mpn_gcd_1);
 }
 
+double
+speed_mpz_nextprime (struct speed_params *s)
+{
+  SPEED_ROUTINE_MPZ_NEXTPRIME (mpz_nextprime);
+}
 
 double
 speed_mpz_jacobi (struct speed_params *s)

--- a/tune/speed.c
+++ b/tune/speed.c
@@ -307,6 +307,9 @@ const struct routine_t {
 #if 0
   { "mpn_gcdext_lehmer",     speed_mpn_gcdext_lehmer     },
 #endif
+
+  { "mpz_nextprime",     speed_mpz_nextprime        },
+
   { "mpz_jacobi",        speed_mpz_jacobi           },
   { "mpn_jacobi_base",   speed_mpn_jacobi_base      },
   { "mpn_jacobi_base_1", speed_mpn_jacobi_base_1    },

--- a/tune/speed.h
+++ b/tune/speed.h
@@ -396,6 +396,7 @@ double speed_mpz_fib_ui (struct speed_params *);
 double speed_mpz_fib2_ui (struct speed_params *);
 double speed_mpz_init_clear (struct speed_params *);
 double speed_mpz_init_realloc_clear (struct speed_params *);
+double speed_mpz_nextprime (struct speed_params *);
 double speed_mpz_jacobi (struct speed_params *);
 double speed_mpz_lucnum_ui (struct speed_params *);
 double speed_mpz_lucnum2_ui (struct speed_params *);
@@ -3096,6 +3097,32 @@ int speed_routine_count_zeros_setup (struct speed_params *, mp_ptr, int, int);
     TMP_FREE;								\
 									\
     s->time_divisor = pieces;						\
+    return t;								\
+  }
+
+/* Calculate nextprime(n) for random n of s->size bits (not limbs). */
+#define SPEED_ROUTINE_MPZ_NEXTPRIME(function)				\
+  {									\
+    unsigned  i;							\
+    mpz_t     n, wp;							\
+    double    t;							\
+									\
+    SPEED_RESTRICT_COND (s->size >= 1);					\
+									\
+    mpz_init (wp);							\
+    mpz_init_set_n (n, s->xp, s->size);					\
+    /* limit to s->size bits, as this function is very slow */		\
+    mpz_tdiv_r_2exp (n, n, s->size);					\
+									\
+    speed_starttime ();							\
+    i = s->reps;							\
+    do									\
+      function (wp, n);							\
+    while (--i != 0);							\
+    t = speed_endtime ();						\
+									\
+    mpz_clear (n);							\
+    mpz_clear (wp);							\
     return t;								\
   }
 


### PR DESCRIPTION
I am currently changing the default behavior of **s->size** being **limps** to **bits** because next_prime is very slow on large (>30 limb) inputs.
```
/* limit to s->size bits, as this function is very slow */
mpz_tdiv_r_2exp (n, n, s->size);
```


with s=limbs, `time ./speed -s 1-50 -t 1 -f 1.05 mpz_nextprime -P nextprime`  takes 2.5 minutes and produces a fairly rough photo
![speed_nextprime](https://user-images.githubusercontent.com/10172976/57469769-44d62580-723c-11e9-9f67-f996cd3f4a30.png)

with s=bits, `time ./speed -s 32-2000 -t 1 -f 1.04 mpz_nextprime -P nextprime` takes ~20 seconds and produces more data points (still a little rough)
![alternate_nextprime_large](https://user-images.githubusercontent.com/10172976/57469848-6fc07980-723c-11e9-9fe2-79827022b374.png)

